### PR TITLE
Add missing GPIO include

### DIFF
--- a/NMEA2000_esp32.cpp
+++ b/NMEA2000_esp32.cpp
@@ -28,6 +28,7 @@ can.h library, which may cause even naming problem.
 */
 
 #include "driver/periph_ctrl.h"
+#include <rom/gpio.h>
 
 #include "soc/dport_reg.h"
 #include "NMEA2000_esp32.h"


### PR DESCRIPTION
`rom/gpio.h` include is required to build with ESP-IDF v5 (= Arduino-esp32 3.x)

Fixes https://github.com/ttlappalainen/NMEA2000/issues/386